### PR TITLE
Files for adi_place class missing in Linux Codeblocks project file

### DIFF
--- a/build/codeblocks_linux/nana_creator.cbp
+++ b/build/codeblocks_linux/nana_creator.cbp
@@ -127,6 +127,7 @@
 		<Unit filename="../../src/main.cpp" />
 		<Unit filename="../../src/namemanager.cpp" />
 		<Unit filename="../../src/namemanager.h" />
+		<Unit filename="../../src/nana_extra/adi_place.cpp" />
 		<Unit filename="../../src/nana_extra/color_helper.cpp" />
 		<Unit filename="../../src/nana_extra/color_helper.h" />
 		<Unit filename="../../src/nana_extra/pgitems.cpp" />

--- a/build/codeblocks_linux/nana_creator.cbp
+++ b/build/codeblocks_linux/nana_creator.cbp
@@ -128,6 +128,7 @@
 		<Unit filename="../../src/namemanager.cpp" />
 		<Unit filename="../../src/namemanager.h" />
 		<Unit filename="../../src/nana_extra/adi_place.cpp" />
+		<Unit filename="../../src/nana_extra/adi_place.hpp" />
 		<Unit filename="../../src/nana_extra/color_helper.cpp" />
 		<Unit filename="../../src/nana_extra/color_helper.h" />
 		<Unit filename="../../src/nana_extra/pgitems.cpp" />


### PR DESCRIPTION
Bug fix for the issue #12. I did not fix Windows codeblocks project file.