### PR TITLE
fix UNIX cmake common_dep being added to common_dep

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -27,7 +27,6 @@ if(UNIX)
         X11::Xft
         X11::Xcursor
         fontconfig
-        common_dep
         stdc++fs
         png
         jpeg


### PR DESCRIPTION
remove "common_dep" from the common_dep list in the cmake on UNIX